### PR TITLE
Make years_back and viruses_per_month options that can be passed

### DIFF
--- a/augur/src/process.py
+++ b/augur/src/process.py
@@ -1,4 +1,4 @@
-import time, os, sys
+import time, os, argparse
 import virus_download, virus_filter, virus_align, virus_clean
 import tree_infer, tree_ancestral, tree_refine, tree_streamline
 from io_util import *
@@ -40,10 +40,8 @@ def main(years_back=3, viruses_per_month=50):
 	write_json(meta, meta_fname)
 
 if __name__ == "__main__":
-	years_back = 3
-	viruses_per_month = 50
-	if (len(sys.argv) > 1):
-		years_back = int(sys.argv[1])
-	if (len(sys.argv) > 2):
-		viruses_per_month = int(sys.argv[2])
-	main(years_back=years_back, viruses_per_month=viruses_per_month)
+	parser = argparse.ArgumentParser(description='Process virus sequences, build tree, and prepare of web visualization')
+	parser.add_argument('-y', '--years_back', type = int, default=3, help='number of past years to sample sequences from')
+	parser.add_argument('-v', '--viruses_per_month', type = int, default = 50, help='number of viruses sampled per month')
+	params = parser.parse_args()
+	main(params.years_back, params.viruses_per_month)

--- a/augur/src/process.py
+++ b/augur/src/process.py
@@ -1,9 +1,9 @@
-import time, os
+import time, os, sys
 import virus_download, virus_filter, virus_align, virus_clean
 import tree_infer, tree_ancestral, tree_refine, tree_streamline
 from io_util import *
 
-def main():
+def main(years_back=3, viruses_per_month=50):
 	"""Run full pipeline"""
 
 	print "--- Start processing at " + time.strftime("%H:%M:%S") + " ---"
@@ -13,7 +13,7 @@ def main():
 	virus_fname = 'data/gisaid_epiflu_sequence.fasta'
 
 	# Filter sequences
-	virus_fname = virus_filter.main(virus_fname)
+	virus_fname = virus_filter.main(virus_fname, years_back=years_back, viruses_per_month=viruses_per_month)
 
 	# Align sequences
 	virus_fname = virus_align.main(virus_fname)
@@ -40,4 +40,10 @@ def main():
 	write_json(meta, meta_fname)
 
 if __name__ == "__main__":
-	main()
+	years_back = 3
+	viruses_per_month = 50
+	if (len(sys.argv) > 1):
+		years_back = int(sys.argv[1])
+	if (len(sys.argv) > 2):
+		viruses_per_month = int(sys.argv[2])
+	main(years_back=years_back, viruses_per_month=viruses_per_month)

--- a/augur/src/virus_filter.py
+++ b/augur/src/virus_filter.py
@@ -8,9 +8,6 @@
 import os, re, time, datetime
 from io_util import *
 
-YEARS_BACK = 3
-VIRUSES_PER_MONTH = 50
-
 def parse_gisaid(fasta):
 	"""Parse FASTA file from GISAID with default header formating"""
 	viruses = []
@@ -132,21 +129,21 @@ def filter_unique(viruses):
 			filtered_viruses.append(v)
 	return filtered_viruses
 
-def streamline(viruses):
+def streamline(viruses, years_back, viruses_per_month):
 	filtered_viruses = []
-	first_year = datetime.datetime.today().year - YEARS_BACK
+	first_year = datetime.datetime.today().year - years_back
 	first_month = datetime.datetime.today().month
 	print "Filtering between " + str(first_month) + "/" + str(first_year) + " and today"
-	print "Selecting " + str(VIRUSES_PER_MONTH) + " viruses per month"
+	print "Selecting " + str(viruses_per_month) + " viruses per month"
 	y = first_year
 	for m in range(first_month,13):
-		filtered_viruses.extend(select_viruses(viruses, y, m))
+		filtered_viruses.extend(select_viruses(viruses, y, m, viruses_per_month))
 	for y in range(first_year+1,datetime.datetime.today().year+1):
 		for m in range(1,13):
-			filtered_viruses.extend(select_viruses(viruses, y, m))
+			filtered_viruses.extend(select_viruses(viruses, y, m, viruses_per_month))
 	return filtered_viruses
 
-def select_viruses(viruses, y, m):
+def select_viruses(viruses, y, m, viruses_per_month):
 	count = 0
 	filtered = []
 	for v in viruses:
@@ -154,11 +151,11 @@ def select_viruses(viruses, y, m):
 		if y == date.year and m == date.month:
 			filtered.append(v)
 			count += 1
-			if count == VIRUSES_PER_MONTH:
+			if count == viruses_per_month:
 				break
 	return filtered
 
-def main(in_fname=None):
+def main(in_fname=None, years_back=3, viruses_per_month=50):
 
 	print "--- Filter at " + time.strftime("%H:%M:%S") + " ---"
 
@@ -197,7 +194,7 @@ def main(in_fname=None):
 	print str(len(viruses)) + " with unique strain names"
 
 	# reduce to manageable volume
-	viruses = streamline(viruses)
+	viruses = streamline(viruses, years_back, viruses_per_month)
 	print str(len(viruses)) + " after streamlining"
 
 	# add outgroup


### PR DESCRIPTION
@rneher ---

This was inspired by rneher/augur@66b63309246a4ff821654c009a2e1bc444047ae1. 

I've included command line options through `sys.argv` that allow calling

```
python src/process.py 5 10
```

to get 10 viruses a month 5 years back. However, I'm not really sure if this is the proper way to implement this or if there is more Pythonic pattern.
