### PR TITLE
Collect and display build commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN pip install DendroPy==3.12.0
 RUN pip install seqmagick==0.5.0
 RUN pip install schedule==0.3.0
 
+# libgit2 and python bindings
+RUN apt-get install -y libgit2
+RUN pip install pygit2==0.22.0
+
 # s3cmd
 RUN apt-get install -y s3cmd
 

--- a/augur/src/process.py
+++ b/augur/src/process.py
@@ -101,8 +101,17 @@ class process(virus_frequencies):
 			write_json(self.frequencies, self.auspice_frequency_fname)
 
 		# Write out metadata
-		print "Writing out metadata"
-		meta = {"updated": time.strftime("X%d %b %Y").replace('X0','X').replace('X','')}
+		print "Writing out metadata"		
+		from pygit2 import Repository
+		from pygit2 import discover_repository
+		current_working_directory = os.getcwd()
+		repository_path = discover_repository(current_working_directory)
+		repo = Repository(repository_path)
+		commit_id = repo[repo.head.target].id
+		
+		meta = {}
+		meta["updated"] = time.strftime("X%d %b %Y").replace('X0','X').replace('X','')
+		meta["commit"] = str(commit_id)
 		if hasattr(self,"date_region_count"):
 			meta["regions"] = self.regions
 			meta["virus_stats"] = [ [str(y)+'-'+str(m)] + [self.date_region_count[(y,m)][reg] for reg in self.regions]

--- a/augur/src/process.py
+++ b/augur/src/process.py
@@ -102,16 +102,18 @@ class process(virus_frequencies):
 
 		# Write out metadata
 		print "Writing out metadata"		
-		from pygit2 import Repository
-		from pygit2 import discover_repository
-		current_working_directory = os.getcwd()
-		repository_path = discover_repository(current_working_directory)
-		repo = Repository(repository_path)
-		commit_id = repo[repo.head.target].id
-		
 		meta = {}
 		meta["updated"] = time.strftime("X%d %b %Y").replace('X0','X').replace('X','')
-		meta["commit"] = str(commit_id)
+		try:
+			from pygit2 import Repository, discover_repository
+			current_working_directory = os.getcwd()
+			repository_path = discover_repository(current_working_directory)
+			repo = Repository(repository_path)
+			commit_id = repo[repo.head.target].id
+			meta["commit"] = str(commit_id)
+		except ImportError:
+			meta["commit"] = "unknown"
+		
 		if hasattr(self,"date_region_count"):
 			meta["regions"] = self.regions
 			meta["virus_stats"] = [ [str(y)+'-'+str(m)] + [self.date_region_count[(y,m)][reg] for reg in self.regions]

--- a/auspice/index.html
+++ b/auspice/index.html
@@ -145,8 +145,8 @@ title: nextflu
 		<hr>
 		Built with love by <a href="http://bedford.io">Trevor Bedford</a> and
 		<a href="https://neherlab.wordpress.com/">Richard Neher</a>.
-		All <a href="http://github.com/blab/nextflu">source code</a> is freely available. Data last updated
-		<span id="updated"></span>.
+		All <a href="http://github.com/blab/nextflu">source code</a> is freely available. Data updated
+		<span id="updated"></span> and processed with commit <span id="commit"></span>.
 		This work would not be possible without the open sharing of genetic data by influenza research groups
 		from all over the world. <a href="acknowledgements/">We gratefully acknowledge their contributions.</a>
 		Give us a shout at <a href="https://twitter.com/trvrb">@trvrb</a> or 

--- a/auspice/js/auspice.js
+++ b/auspice/js/auspice.js
@@ -1028,6 +1028,12 @@ d3.json("data/tree.json", function(error, root) {
 d3.json("data/meta.json", function(error, json) {
 	if (error) return console.warn(error);
 	d3.select("#updated").text(json['updated']);
+	commit_id = json['commit'];
+	short_id = commit_id.substring(0, 6);	
+	d3.select("#commit")
+		.append("a")
+		.attr("href", "http://github.com/blab/nextflu/commit/" + commit_id)
+		.text(short_id);
 });
 
 d3.json("data/sequences.json", function(error, json) {


### PR DESCRIPTION
This is up at [dev.nextflu.org](http://dev.nextflu.org/). I thought it would be useful to keep track of what commit was used to build a tree. Especially useful when comparing dev to production.

However, this requires libgit2 and Python bindings pygit2. Look [here](http://www.pygit2.org/install.html) for installation instructions.

Pull if you're happy.
