### PR TITLE
S3 integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN pip install biopython==1.64
 RUN pip install DendroPy==3.12.0
 RUN pip install seqmagick==0.5.0
 RUN pip install schedule==0.3.0
+RUN pip install boto==2.38.0
 
 # libgit2 and python bindings
 RUN apt-get install -y libgit2

--- a/augur/src/make_all.py
+++ b/augur/src/make_all.py
@@ -43,7 +43,7 @@ def push_fasta_to_s3(lineage, directory = 'data/', bucket = 'nextflu-data'):
 	k.set_contents_from_filename(directory+fasta)
 	print fasta,"uploaded"
 	
-def push_json_to_s3(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev'):
+def push_json_to_s3(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev', cloudfront = 'E1XKGZG0ZTX4YN'):
 	"""Upload JSON files to S3 bucket"""
 	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
 	directory = directory.rstrip('/')+'/'
@@ -53,12 +53,18 @@ def push_json_to_s3(lineage, directory = '../auspice/data/', bucket = 'nextflu-d
 	b = conn.get_bucket(bucket)
 	k = boto.s3.key.Key(b)
 
+	paths = []	
+
 	print "Uploading JSONs for",lineage
 	for postfix in ['_tree.json', '_sequences.json', '_frequencies.json', '_meta.json']:
 		json = lineage + postfix
 		k.key = 'data/'+json
 		k.set_contents_from_filename(directory+json)
-		print json,"uploaded"	
+		print json,"uploaded"
+		paths.append('data/'+json)
+
+	c = boto.connect_cloudfront()
+	c.create_invalidation_request(cloudfront, paths)
 
 def ammend_fasta(fname, lineage, threshold = 10, directory = 'data/'):
 	directory = directory.rstrip('/')+'/'

--- a/augur/src/make_all.py
+++ b/augur/src/make_all.py
@@ -9,8 +9,9 @@ patterns = {('A / H3N2', ''):'H3N2',
 			('B / H0N0', 'Yamagata'):'Yam',
 			('A / H1N1', 'seasonal'):'H1N1',
 			}
+lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam']
 
-def pull_fasta_from_s3(lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], directory = 'data/', bucket = 'nextflu-data'):
+def pull_fasta_from_s3(lineage, directory = 'data/', bucket = 'nextflu-data'):
 	"""Retrieve FASTA files from S3 bucket"""
 	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
 	directory = directory.rstrip('/')+'/'
@@ -20,14 +21,13 @@ def pull_fasta_from_s3(lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], directory =
 	b = conn.get_bucket(bucket)
 	k = boto.s3.key.Key(b)
 
-	for lineage in lineages:
-		print "Retrieving FASTA for",lineage
-		fasta = lineage+'_gisaid_epiflu_sequence.fasta'
-		k.key = fasta
-		k.get_contents_to_filename(directory+fasta)
-		print fasta,"retrieved"
+	print "Retrieving FASTA for",lineage
+	fasta = lineage+'_gisaid_epiflu_sequence.fasta'
+	k.key = fasta
+	k.get_contents_to_filename(directory+fasta)
+	print fasta,"retrieved"
 		
-def push_fasta_to_s3(lineages= ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], directory = 'data/', bucket = 'nextflu-data'):
+def push_fasta_to_s3(lineage, directory = 'data/', bucket = 'nextflu-data'):
 	"""Upload FASTA files to S3 bucket"""
 	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
 	directory = directory.rstrip('/')+'/'
@@ -37,52 +37,50 @@ def push_fasta_to_s3(lineages= ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], directory = 'd
 	b = conn.get_bucket(bucket)
 	k = boto.s3.key.Key(b)
 
-	for lineage in lineages:
-		print "Uploading FASTA for",lineage
-		fasta = lineage+'_gisaid_epiflu_sequence.fasta'
-		k.key = fasta
-		k.set_contents_from_filename(directory+fasta)
-		print fasta,"uploaded"
+	print "Uploading FASTA for",lineage
+	fasta = lineage+'_gisaid_epiflu_sequence.fasta'
+	k.key = fasta
+	k.set_contents_from_filename(directory+fasta)
+	print fasta,"uploaded"
 
-def ammend_files(fname, lineages= ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], threshold = 10, directory = 'data/'):
+def ammend_fasta(fname, lineage, threshold = 10, directory = 'data/'):
 	directory = directory.rstrip('/')+'/'
-	updated = []
+	updated = False
 
-	for lineage in lineages:
-		print '\nLineage',lineage
-		ex_fname = directory+lineage+'_gisaid_epiflu_sequence.fasta'
-		existing = set()
-		if not os.path.isfile(ex_fname):
-			print "No existing file found for",lineage, ex_fname
-		else:
-			for seq in SeqIO.parse(ex_fname, 'fasta'):
-				acc = int(seq.description.split('|')[-1].strip())
-				existing.add(acc)
-		print "Found", len(existing), 'existing for lineage', lineage 
+	ex_fname = directory+lineage+'_gisaid_epiflu_sequence.fasta'
+	existing = set()
+	if not os.path.isfile(ex_fname):
+		print "No existing file found for",lineage, ex_fname
+	else:
+		for seq in SeqIO.parse(ex_fname, 'fasta'):
+			acc = int(seq.description.split('|')[-1].strip())
+			existing.add(acc)
+	print "Found", len(existing), 'existing for lineage', lineage 
 
-		new_seqs = []
-		seq_fname = directory + fname
-		if not os.path.isfile(seq_fname):
-			print "File with new sequences does not exist ", seq_fname
-			continue
-		else:
-			for seq in SeqIO.parse(seq_fname, 'fasta'):
-				fields = map(lambda x:x.strip(), seq.description.split('|'))
-				tmp_lineage = (fields[2], fields[4])
-				if tmp_lineage in patterns:
-					if patterns[tmp_lineage]==lineage:
-						acc = int(fields[-1])
-						if acc not in existing:
-							new_seqs.append(seq)
-				else:
-					if verbose:
-						print tmp_lineage,"not found"
+	new_seqs = []
+	seq_fname = directory + fname
+	if not os.path.isfile(seq_fname):
+		print "File with new sequences does not exist ", seq_fname
+		return updated
+	else:
+		for seq in SeqIO.parse(seq_fname, 'fasta'):
+			fields = map(lambda x:x.strip(), seq.description.split('|'))
+			tmp_lineage = (fields[2], fields[4])
+			if tmp_lineage in patterns:
+				if patterns[tmp_lineage]==lineage:
+					acc = int(fields[-1])
+					if acc not in existing:
+						new_seqs.append(seq)
+			else:
+				if verbose:
+					print tmp_lineage,"not found"
 
-		print "Found", len(new_seqs), 'new for lineage', lineage 
-		if len(new_seqs)>threshold:
-			with open(ex_fname, 'a') as outfile:
-				SeqIO.write(new_seqs, outfile, 'fasta')
-			updated.append(lineage)
+	print "Found", len(new_seqs), 'new for lineage', lineage
+	if len(new_seqs)>threshold:
+		with open(ex_fname, 'a') as outfile:
+			SeqIO.write(new_seqs, outfile, 'fasta')
+		updated = True
+
 	return updated
 
 
@@ -90,44 +88,35 @@ if __name__=="__main__":
 	parser = argparse.ArgumentParser(description = "ammend existing files with downloaded viruses, rerun")
 	parser.add_argument('--infile', type = str, default = "gisaid_epiflu_sequence.fasta")
 	parser.add_argument('--bin', type = str, default = "python")
-	parser.add_argument('--ATG', action = "store_true", default = False, help ="include full HA sequence starting at ATG")
+	parser.add_argument('--ATG', action = "store_true", default = False, help = "include full HA sequence starting at ATG")
 	parser.add_argument('--all', action = "store_true", default = False)
-	parser.add_argument('--s3', action = "store_true", default = False, help="pull FASTA files from S3")	
+	parser.add_argument('--s3', action = "store_true", default = False, help = "pull FASTA files from S3")
+	parser.add_argument('--threshold', type = float, default = 10.0, help = "number of new sequences required to rerun pipeline")	
 	parser.add_argument('-r', type = float, default = 1.0)
 	params = parser.parse_args()
-	
-	if params.s3:
-		pull_fasta_from_s3(lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], directory = 'data/', bucket = 'nextflu-data')
-
-	if params.all:	
-		run_pipeline = ammend_files(params.infile, lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], threshold = 0, directory = 'data/')
-		run_pipeline = ['H3N2', 'H1N1pdm', 'Vic', 'Yam']
-	else:
-		run_pipeline = ammend_files(params.infile, lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], threshold = 10, directory = 'data/')
 
 	common_args = ['--skip', 'genotype_frequencies','-r', params.r]
 	if params.ATG: common_args.append('--ATG')
 
-	if 'H3N2' in run_pipeline:
-		call = map(str, [params.bin, 'src/H3N2_process.py', '-v', 50, '-y', 3,  '--prefix', 'data/H3N2_'] + common_args)
-		print call
-		subprocess.call(call)
-	if 'H1N1' in run_pipeline:
-		call = map(str, [params.bin, 'src/H1N1historical_process.py', '-v', 20, '--interval', 1990, 2010, '--prefix', 'data/H1N1_']+ common_args)
-		print call
-		subprocess.call(call)
-	if 'H1N1pdm' in run_pipeline:
-		call = map(str, [params.bin, 'src/H1N1pdm_process.py', '-v', 30, '-y', 6, '--prefix', 'data/H1N1pdm_']+ common_args)
-		print call
-		subprocess.call(call)
-	if 'Vic' in run_pipeline:
-		call = map(str, [params.bin, 'src/Vic_process.py', '-v', 30, '-y', 6, '--prefix', 'data/Vic_'] + common_args)
-		print call
-		subprocess.call(call)
-	if 'Yam' in run_pipeline:
-		call = map(str, [params.bin, 'src/Yam_process.py', '-v', 30, '-y', 6, '--prefix', 'data/Yam_'] + common_args)
-		print call
-		subprocess.call(call)
-
-	if params.s3:
-		push_fasta_to_s3(lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam'], directory = 'data/', bucket = 'nextflu-data')		
+	for lineage in lineages:
+		print '\nLineage',lineage	
+		if params.s3:
+			pull_fasta_from_s3(lineage, directory = 'data/', bucket = 'nextflu-data')
+		if params.all:
+			params.threshold = 0
+		run = ammend_fasta(params.infile, lineage, threshold = params.threshold, directory = 'data/')
+		if run:
+			if lineage == 'H3N2':
+				call = map(str, [params.bin, 'src/H3N2_process.py', '-v', 50, '-y', 3,  '--prefix', 'data/H3N2_'] + common_args)
+			if lineage == 'H1N1':
+				call = map(str, [params.bin, 'src/H1N1historical_process.py', '-v', 20, '--interval', 1990, 2010, '--prefix', 'data/H1N1_']+ common_args)
+			if lineage == 'H1N1pdm':
+				call = map(str, [params.bin, 'src/H1N1pdm_process.py', '-v', 30, '-y', 6, '--prefix', 'data/H1N1pdm_']+ common_args)
+			if lineage == 'Vic':
+				call = map(str, [params.bin, 'src/Vic_process.py', '-v', 30, '-y', 6, '--prefix', 'data/Vic_'] + common_args)
+			if lineage == 'Yam':
+				call = map(str, [params.bin, 'src/Yam_process.py', '-v', 30, '-y', 6, '--prefix', 'data/Yam_'] + common_args)
+			print call
+			subprocess.call(call)
+			if params.s3:
+				push_fasta_to_s3(lineage, directory = 'data/', bucket = 'nextflu-data')			

--- a/augur/src/production.py
+++ b/augur/src/production.py
@@ -21,7 +21,7 @@ def pull_from_dev(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev
 		k.get_contents_to_filename(directory+json)
 		print json,"retrieved"
 	
-def push_to_production(lineage, directory = '../auspice/data/', bucket = 'nextflu'):
+def push_to_production(lineage, directory = '../auspice/data/', bucket = 'nextflu', cloudfront = 'E1ZD3XPSGXABBI'):
 	"""Upload JSON files to S3 production bucket"""
 	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
 	directory = directory.rstrip('/')+'/'
@@ -31,12 +31,18 @@ def push_to_production(lineage, directory = '../auspice/data/', bucket = 'nextfl
 	b = conn.get_bucket(bucket)
 	k = boto.s3.key.Key(b)
 
+	paths = []
+
 	print "Uploading JSONs for", lineage, "to bucket", bucket
 	for postfix in ['_tree.json', '_sequences.json', '_frequencies.json', '_meta.json']:
 		json = lineage + postfix
 		k.key = 'data/'+json
 		k.set_contents_from_filename(directory+json)
 		print json,"uploaded"
+		paths.append('data/'+json)
+
+	c = boto.connect_cloudfront()
+	c.create_invalidation_request(cloudfront, paths)
 
 if __name__=="__main__":
 	parser = argparse.ArgumentParser(description = "sync JSONs between local storage, dev server and production server")	

--- a/augur/src/production.py
+++ b/augur/src/production.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+import argparse
+
+verbose = False
+lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam']
+
+def pull_from_dev(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev'):
+	"""Retrieve JSON files from S3 dev bucket"""
+	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
+	directory = directory.rstrip('/')+'/'
+
+	import boto
+	conn = boto.connect_s3()
+	b = conn.get_bucket(bucket)
+	k = boto.s3.key.Key(b)
+
+	print "Retrieving JSONs for", lineage, "from bucket", bucket
+	for postfix in ['_tree.json', '_sequences.json', '_frequencies.json', '_meta.json']:
+		json = lineage + postfix
+		k.key = 'data/'+json
+		k.get_contents_to_filename(directory+json)
+		print json,"retrieved"
+	
+def push_to_production(lineage, directory = '../auspice/data/', bucket = 'nextflu'):
+	"""Upload JSON files to S3 production bucket"""
+	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
+	directory = directory.rstrip('/')+'/'
+
+	import boto
+	conn = boto.connect_s3()
+	b = conn.get_bucket(bucket)
+	k = boto.s3.key.Key(b)
+
+	print "Uploading JSONs for", lineage, "to bucket", bucket
+	for postfix in ['_tree.json', '_sequences.json', '_frequencies.json', '_meta.json']:
+		json = lineage + postfix
+		k.key = 'data/'+json
+		k.set_contents_from_filename(directory+json)
+		print json,"uploaded"
+
+if __name__=="__main__":
+	parser = argparse.ArgumentParser(description = "sync JSONs between local storage, dev server and production server")	
+	parser.add_argument('--dev_bucket', type = str, default = "nextflu-dev", help = "dev bucket for JSON files")
+	parser.add_argument('--live_bucket', type = str, default = "nextflu", help = "dev bucket for JSON files")
+	parser.add_argument('--pull', action = "store_true", default = False, help = "pull local files from dev")
+	parser.add_argument('--push', action = "store_true", default = False, help = "push local files to production")
+	parser.add_argument('--sync', action = "store_true", default = False, help = "sync dev to production")	
+	params = parser.parse_args()
+
+	for lineage in lineages:
+		print '\nLineage',lineage
+		if params.pull or params.sync:
+			pull_from_dev(lineage, directory = '../auspice/data/', bucket = params.dev_bucket)
+		if params.push or params.sync:
+			push_to_production(lineage, directory = '../auspice/data/', bucket = params.live_bucket)			

--- a/augur/src/s3_sync.py
+++ b/augur/src/s3_sync.py
@@ -4,7 +4,7 @@ import argparse
 verbose = False
 lineages = ['H3N2', 'H1N1pdm', 'Vic', 'Yam']
 
-def pull_from_dev(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev'):
+def pull(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev'):
 	"""Retrieve JSON files from S3 dev bucket"""
 	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
 	directory = directory.rstrip('/')+'/'
@@ -21,7 +21,7 @@ def pull_from_dev(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev
 		k.get_contents_to_filename(directory+json)
 		print json,"retrieved"
 	
-def push_to_production(lineage, directory = '../auspice/data/', bucket = 'nextflu', cloudfront = 'E1ZD3XPSGXABBI'):
+def push(lineage, directory = '../auspice/data/', bucket = 'nextflu-dev', cloudfront = 'E1XKGZG0ZTX4YN'):
 	"""Upload JSON files to S3 production bucket"""
 	"""Boto expects environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY"""
 	directory = directory.rstrip('/')+'/'
@@ -47,15 +47,23 @@ def push_to_production(lineage, directory = '../auspice/data/', bucket = 'nextfl
 if __name__=="__main__":
 	parser = argparse.ArgumentParser(description = "sync JSONs between local storage, dev server and production server")	
 	parser.add_argument('--dev_bucket', type = str, default = "nextflu-dev", help = "dev bucket for JSON files")
-	parser.add_argument('--live_bucket', type = str, default = "nextflu", help = "dev bucket for JSON files")
-	parser.add_argument('--pull', action = "store_true", default = False, help = "pull local files from dev")
-	parser.add_argument('--push', action = "store_true", default = False, help = "push local files to production")
+	parser.add_argument('--pro_bucket', type = str, default = "nextflu", help = "production bucket for JSON files")
+	parser.add_argument('--dev_cloudfront', type = str, default = "E1XKGZG0ZTX4YN", help = "dev cloudfront distribution")
+	parser.add_argument('--pro_cloudfront', type = str, default = "E1ZD3XPSGXABBI", help = "production cloudfront distribution")	
+	parser.add_argument('--pull_dev', action = "store_true", default = False, help = "pull local files from dev")
+	parser.add_argument('--push_dev', action = "store_true", default = False, help = "push local files to dev")
+	parser.add_argument('--pull_pro', action = "store_true", default = False, help = "pull local files from pro")
+	parser.add_argument('--push_pro', action = "store_true", default = False, help = "push local files to pro")	
 	parser.add_argument('--sync', action = "store_true", default = False, help = "sync dev to production")	
 	params = parser.parse_args()
 
 	for lineage in lineages:
 		print '\nLineage',lineage
-		if params.pull or params.sync:
-			pull_from_dev(lineage, directory = '../auspice/data/', bucket = params.dev_bucket)
-		if params.push or params.sync:
-			push_to_production(lineage, directory = '../auspice/data/', bucket = params.live_bucket)			
+		if params.pull_dev or params.sync:
+			pull(lineage, directory = '../auspice/data/', bucket = params.dev_bucket)
+		if params.push_dev:
+			push(lineage, directory = '../auspice/data/', bucket = params.dev_bucket, cloudfront = params.dev_cloudfront)
+		if params.pull_pro:
+			pull(lineage, directory = '../auspice/data/', bucket = params.pro_bucket)
+		if params.push_pro or params.sync:
+			push(lineage, directory = '../auspice/data/', bucket = params.pro_bucket, cloudfront = params.pro_cloudfront)						


### PR DESCRIPTION
This branch modifies `make_all.py` to push and pull from S3. The S3 bucket `nextflu-data` is used to store and sync FASTA files. After the pipeline is run auspice JSONs are pushed to the bucket `nextflu-dev`. At this point, I'm picturing the production pipeline to be:
1. Download new `gisaid_epiflu_sequence.fasta`.
2. Run `python src/make_all.py --s3`.
3. Check locally or at `dev.nextflu.org` to see that everything was okay.
4. Sync JSONs in `nextflu.org` with JSONs at `dev.nextflu.org` (writing script for this now).

In this case, the build script could be running on a server somewhere and we could still easily check output. Every day, the build script is run with a new sequence dump. We look at `dev.nextflu.org` and push live if nothing broke. Once all the kinks are worked out, `make_all.py` could push directly to production.
