### PR TITLE
Change cursor upon mouse-over in variability chart

### DIFF
--- a/auspice/js/frequencies.js
+++ b/auspice/js/frequencies.js
@@ -243,7 +243,13 @@ d3.json(path + file_prefix + "frequencies.json", function(error, json){
 					colorByGenotypePosition([d.x-1]);
 					d3.select("#gt-color").property("value", d.x);
 				}
-		    }            
+		    },
+		    onmouseover: function (d){
+		    	document.body.style.cursor = "pointer";
+		    },
+		    onmouseout: function (d){
+		    	document.body.style.cursor = "default";
+		    },
 		},
 		bar: {width: 2},
 	    tooltip: {


### PR DESCRIPTION
> not ideal since plot only responds to click on the actual bar, while mouse-over events seem to listen only to the x-axis

This did seem strange. Couldn't get a different behavior. Still, a definite improvement.
