### PR TITLE
Adjust frequencies to be more stable

### DIFF
--- a/augur/src/process.py
+++ b/augur/src/process.py
@@ -31,7 +31,7 @@ virus_config = {
 	# frequency estimation parameters
 	'aggregate_regions': [  ("global", None), ("NA", ["NorthAmerica"]), ("EU", ["Europe"]), 
 							("AS", ["China", "SoutheastAsia", "JapanKorea"]), ("OC", ["Oceania"]) ],
-	'frequency_stiffness':5.0,
+	'frequency_stiffness':10.0,
 	'verbose':2, 
 	'tol':2e-4, #tolerance for frequency optimization
 	'pc':1e-3, #pseudocount for frequencies 
@@ -429,4 +429,4 @@ class process(virus_frequencies):
 		if 'nuc_clades' in tasks:
 			self.all_clade_frequencies(gene='nuc') 
 		if 'tree' in tasks:
-			self.all_tree_frequencies() 
+			self.all_tree_frequencies(threshold = 5) 

--- a/augur/src/process.py
+++ b/augur/src/process.py
@@ -33,10 +33,10 @@ virus_config = {
 							("AS", ["China", "SoutheastAsia", "JapanKorea"]), ("OC", ["Oceania"]) ],
 	'frequency_stiffness':5.0,
 	'verbose':2, 
-	'tol':1e-4, #tolerance for frequency optimization
+	'tol':2e-4, #tolerance for frequency optimization
 	'pc':1e-3, #pseudocount for frequencies 
 	'extra_pivots': 12,  # number of pivot point for or after the last observations of a mutations
-	'inertia':0.7,		# fraction of frequency change carry over in the stiffness term
+	'inertia':0.5,		# fraction of frequency change carry over in the stiffness term
 	'n_iqd':3,     # standard deviations from clock
 }
 


### PR DESCRIPTION
Recent frequencies for 3c2.a did not seem real. Too much weight to a few recent samples. This fixes this.

See if you like it. I have it run for just H3N2/3y on dev: http://dev.nextflu.org/H3N2/3y/.
