### PR TITLE
Filter outgroup strain from list of input viruses.

### DIFF
--- a/augur/src/virus_filter.py
+++ b/augur/src/virus_filter.py
@@ -102,10 +102,11 @@ class virus_filter(object):
 		'''
 		Keep only the first isolate of a strain
 		'''
+		outgroup_label = self.outgroup['strain'].upper()
 		filtered_viruses = []
 		for v in self.viruses:
 			label = v['strain'].upper()
-			if not label in self.strain_lookup:
+			if not label in self.strain_lookup and label != outgroup_label:
 				filtered_viruses.append(v)
 				self.strain_lookup[label]=v
 		self.viruses=filtered_viruses


### PR DESCRIPTION
This commit resolves a data-dependent bug caused by the outgroup strain being present twice in the list of viruses to analyze (once from the input set of viruses and once by being the outgroup).
