### PR TITLE
Fix mixed content warnings by using https:// for embedded resources

### DIFF
--- a/auspice/help/index.html
+++ b/auspice/help/index.html
@@ -21,7 +21,7 @@ categories:
 	<div class="col-md-9">
 		<a name="tutorial">
 			<div class="embed-responsive embed-responsive-16by9">
-				<iframe allowfullscreen src="http://www.youtube.com/embed/_MZk1DDNjMA?autoplay=0">
+				<iframe allowfullscreen src="https://www.youtube.com/embed/_MZk1DDNjMA?autoplay=0">
 				</iframe>
 			</div>
 		</a>

--- a/auspice/methods/index.html
+++ b/auspice/methods/index.html
@@ -197,6 +197,6 @@ categories:
 
 <!-- MathJax support -->
 <script type="text/javascript"
- src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+ src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <!-- MathJax config -->
 <script src="/js/mathjax.config.js"></script>

--- a/auspice/reports/index.html
+++ b/auspice/reports/index.html
@@ -32,6 +32,6 @@ title: nextflu / reports
 
 <!-- MathJax support -->
 <script type="text/javascript"
- src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+ src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <!-- MathJax config -->
 <script src="/js/mathjax.config.js"></script>


### PR DESCRIPTION
Browsers warn when pages served via https:// (like nextflu) include resources served over http://, as noted by Netlify's deploy process¹, which occasionally results in warning emails².

¹ e.g. <https://app.netlify.com/sites/nextflu/deploys/63bc65f3ec7cb3069d9d38ea>
² e.g. <https://support.nextstrain.org/agent/nextstrain/nextstrain/tickets/details/668036000003352015>