### PR TITLE
auspice/_config.yml: exclude "vendor/"

### DIFF
--- a/auspice/_config.yml
+++ b/auspice/_config.yml
@@ -23,3 +23,4 @@ exclude:
   - "analysis/"
   - "aero-deploy.tar.gz"
   - "aero-debug.log"
+  - "vendor/"


### PR DESCRIPTION
GitHub Action ruby/setup-ruby does not allow customization of the vendor path¹ so just exclude the hard-coded `vendor/` path in the config.

¹ https://github.com/ruby/setup-ruby/issues/136

---

 This is required for setting up the GitHub Action workflow to deploy the private builds to netlify. Without this change, we run into errors when [trying to build the site with jekyll](https://github.com/joverlee521/nextstrain-testing/actions/runs/6115907081/job/16600262613#step:4:10):

```
ERROR: YOUR SITE COULD NOT BE BUILT:
------------------------------------
Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/2.3.0/gems/jekyll-3.1.2/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

